### PR TITLE
Small fix in .ci/build was needed as paths changed after migration

### DIFF
--- a/.ci/build
+++ b/.ci/build
@@ -65,12 +65,12 @@ if [[ -z "$LOCAL_BUILD" ]]; then
     -a \
     -v \
     -o ${BINARY_PATH}/linux-amd64/manager \
-    github.com/gardener/hvpa-controller/cmd/manager
+    main.go
 
 # If the LOCAL_BUILD environment variable is set, we simply run `go build`.
 else
   go build \
     -v \
     -o ${BINARY_PATH}/manager \
-    github.com/gardener/hvpa-controller/cmd/manager
+    main.go
 fi


### PR DESCRIPTION
**What this PR does / why we need it**:
Small fix in .ci/build was needed as paths changed after migration to kubebuilder v2

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator

```
